### PR TITLE
Improve memory handling across pipeline

### DIFF
--- a/fkio/impl/midjourney/MidJourneySource.py
+++ b/fkio/impl/midjourney/MidJourneySource.py
@@ -162,33 +162,40 @@ class MidJourneySource(_FkSource):
 
             return True
 
-        for attempt in range(3):
-            try:
-                driver.get("https://www.midjourney.com/home/")
-                time.sleep(10)
+        try:
+            for attempt in range(3):
+                try:
+                    driver.get("https://www.midjourney.com/home/")
+                    time.sleep(10)
 
-                if not _click_signin_button():
-                    continue
+                    if not _click_signin_button():
+                        continue
 
-                time.sleep(5)
-                if not _handle_login_form():
-                    continue
+                    time.sleep(5)
+                    if not _handle_login_form():
+                        continue
 
-                time.sleep(5)
-                if not _handle_additional_authorization():
-                    continue
+                    time.sleep(5)
+                    if not _handle_additional_authorization():
+                        continue
 
-                time.sleep(5)
-                if not _authorize_app():
-                    continue
+                    time.sleep(5)
+                    if not _authorize_app():
+                        continue
 
-                time.sleep(5)
-                if not _save_cookies():
-                    continue
+                    time.sleep(5)
+                    if not _save_cookies():
+                        continue
 
-            except Exception as e:
-                print(f"Login attempt {attempt} failed...")
-                traceback.print_exception(e)
+                except Exception as e:
+                    print(f"Login attempt {attempt} failed...")
+                    traceback.print_exception(e)
+        finally:
+            if driver is not None:
+                try:
+                    driver.quit()
+                except Exception:
+                    pass
 
     def yield_next(self) -> _FkImage:
         pass

--- a/fktasks/FkTask.py
+++ b/fktasks/FkTask.py
@@ -180,6 +180,15 @@ class FkImage:
             ) as caption_file:
                 caption_file.write(self.caption_text)
 
+    def release(self):
+        """Release loaded image data without marking the image as destroyed."""
+        if self._image is not None:
+            self._image.close()
+
+        self._image = None
+        self._cv2_image = None
+        self._cv2_grayscale_image = None
+
     def destroy(self):
         if self._destroyed:
             return


### PR DESCRIPTION
## Summary
- add `FkImage.release` for partial cleanup
- handle task resubmission by releasing image data before requeue
- bound executor queues and context factory depth
- clean up completed save futures
- ensure Selenium driver is quit in `MidJourneySource`

## Testing
- `flake8 fktasks/FkPipeline.py fktasks/FkTask.py fkio/impl/midjourney/MidJourneySource.py | head`
- `mypy fktasks/FkPipeline.py fktasks/FkTask.py fkio/impl/midjourney/MidJourneySource.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405009ee24832c8a0f525fed520f78